### PR TITLE
Add single mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,19 @@ This can be any group of 2+ captures with varying viewing angles that allows der
 The overlap of the captures should be significantly high (usually 75 % or more) and
 the time difference between the captures should be minimal (usually a couple of minutes or less).
 
-- Example:
-  - [Collection](examples/collection.json): A Collection pointing to a pair of stereo imagery as Items.
-  - [Item 1](examples/item1.json): The first Item of the pair.
-  - [Item 2](examples/item2.json): The second Item of the pair.
+- Examples:
+  - Multi Mode (recommended):
+    - [Collection](examples/multi/collection.json): A Collection pointing to a pair of stereo imagery as Items.
+    - [Item 1](examples/multi/item1.json): The first Item of the pair.
+    - [Item 2](examples/multi/item2.json): The second Item of the pair.
+  - Single Mode: [Item](examples/single/item.json): A single Item where each stereo capture is an Asset.
 - [JSON Schema](json-schema/schema.json)
 - [Changelog](./CHANGELOG.md)
 
 ## Fields
 
-The extension allows to provide the captures as multiple Items.
+The extension allows to provide the captures either 
+as multiple Items (Multi Mode, recommended) or in a single Item as assets (Single Mode).
 
 The field in the table below can be used in these parts of STAC documents:
 - [x] Catalogs
@@ -33,10 +36,11 @@ The field in the table below can be used in these parts of STAC documents:
 | Field Name           | Type    | Description |
 | -------------------- | ------- | ----------- |
 | stereo-img:count     | integer | **REQUIRED**. The total number of captures in the group. 2 for stereo imagery (minimum), 3 for tri-stereo imagery, etc. |
-| stereo-img:group     | string  | A unique identifier that for the group of captures. Helps to search for all images of a group. |
+| stereo-img:group     | string  | Multi Mode only: A unique identifier that for the group of captures. Helps to search for all images of a group. |
 
 The field in the table below can be used in these parts of STAC documents:
 - [x] Item Properties (incl. Summaries in Collections)
+- [x] Assets (for Items)
 - [x] Links (in Items)
 
 | Field Name           | Type    | Description |
@@ -46,7 +50,13 @@ The field in the table below can be used in these parts of STAC documents:
 The order of the captures that is reflected in `stereo-img:number` can usually be derived
 from the acquisition time (`datetime`) unless there's another specific order for the captures.
 
-It is recommended to provide exact viewing angles, geometries and timestamps for each capture in the Item Properties.
+It is recommended to provide exact viewing angles, geometries and timestamps for each capture.
+Depending on the structure, the fields may either reside in the Item Properties or in the Assets.
+
+If the captures are provided in a single Item as assets:
+- the Item Geometry should be the union of all captures
+- the start and end datetime for the interval of all captures should be provided
+
 Additionally, it is recommended to identify the actual stereo imagery in the assets with the role `data`.
 
 ## Relation types
@@ -54,9 +64,9 @@ Additionally, it is recommended to identify the actual stereo imagery in the ass
 The following types should be used as applicable `rel` types in the
 [Link Object](https://github.com/radiantearth/stac-spec/tree/master/item-spec/item-spec.md#link-object).
 
-| Type    | Description |
-| ------- | ----------- |
-| related | Link to the other captures in the group. |
+| Type    | Description                                                             |
+| ------- | ----------------------------------------------------------------------- |
+| related | Multi Mode only: Link to the other captures in the group (recommended). |
 
 If the `related` relation type is used, it is **REQUIRED** to provide the `stereo-img:number` and `type` fields in the Link Object.
 This allows clients to distinguish them from other "related" links.

--- a/examples/multi/collection.json
+++ b/examples/multi/collection.json
@@ -32,7 +32,7 @@
   },
   "links": [
     {
-      "href": "https://raw.githubusercontent.com/stac-extensions/stereo-imagery/main/examples/collection.json",
+      "href": "https://raw.githubusercontent.com/stac-extensions/stereo-imagery/main/examples/multi/collection.json",
       "rel": "self",
       "type": "application/json"
     },

--- a/examples/multi/item1.json
+++ b/examples/multi/item1.json
@@ -46,7 +46,7 @@
   },
   "links": [
     {
-      "href": "https://raw.githubusercontent.com/stac-extensions/stereo-imagery/main/examples/item1.json",
+      "href": "https://raw.githubusercontent.com/stac-extensions/stereo-imagery/main/examples/multi/item1.json",
       "rel": "self",
       "type": "application/geo+json"
     },

--- a/examples/multi/item2.json
+++ b/examples/multi/item2.json
@@ -46,7 +46,7 @@
   },
   "links": [
     {
-      "href": "https://raw.githubusercontent.com/stac-extensions/stereo-imagery/main/examples/item2.json",
+      "href": "https://raw.githubusercontent.com/stac-extensions/stereo-imagery/main/examples/multi/item2.json",
       "rel": "self",
       "type": "application/geo+json"
     },

--- a/examples/single/item.json
+++ b/examples/single/item.json
@@ -1,0 +1,68 @@
+{
+  "stac_version": "1.0.0",
+  "stac_extensions": [
+    "https://stac-extensions.github.io/stereo-imagery/v1.0.0/schema.json"
+  ],
+  "type": "Feature",
+  "id": "single-item-example",
+  "bbox": [
+    172.9,
+    1.3,
+    173,
+    1.4
+  ],
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [
+      [
+        [
+          172.9,
+          1.3
+        ],
+        [
+          173,
+          1.3
+        ],
+        [
+          173,
+          1.4
+        ],
+        [
+          172.9,
+          1.4
+        ],
+        [
+          172.9,
+          1.3
+        ]
+      ]
+    ]
+  },
+  "properties": {
+    "datetime": null,
+    "start_datetime": "2020-12-11T22:38:32.456Z",
+    "end_datetime": "2020-12-11T22:38:33.321Z",
+    "stereo-img:count": 2
+  },
+  "links": [
+    {
+      "href": "https://raw.githubusercontent.com/stac-extensions/stereo-imagery/main/examples/single/item.json",
+      "rel": "self",
+      "type": "application/geo+json"
+    }
+  ],
+  "assets": {
+    "capture1": {
+      "href": "https://example.com/examples/img1.tif",
+      "type": "image/tiff",
+      "stereo-img:number": 1,
+      "datetime": "2020-12-11T22:38:32.456Z"
+    },
+    "capture2": {
+      "href": "https://example.com/examples/img2.tif",
+      "type": "image/tiff",
+      "stereo-img:number": 2,
+      "datetime": "2020-12-11T22:38:33.321Z"
+    }
+  }
+}

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -40,6 +40,12 @@
                 }
               ]
             },
+            "assets": {
+              "type": "object",
+              "additionalProperties": {
+                "$ref": "#/definitions/number_field"
+              }
+            },
             "links": {
               "type": "array",
               "items": {


### PR DESCRIPTION
Adds an official way to have stereo imagery in a single STAC Item. 
See #3 for details and further discussions.